### PR TITLE
generate-cross-file: Let meson handle -O and -Wall

### DIFF
--- a/gst-build-helper/generate-cross-file.py
+++ b/gst-build-helper/generate-cross-file.py
@@ -44,7 +44,6 @@ def get_toolchain_prefix(options):
 
 
 def get_cflags(options):
-    cflags = ' -Wall -g -O2'
     if options.target_arch == "armv7":
         cflags = ' -march=armv7-a '
     cflags = cflags + ' ' + options.custom_cflags


### PR DESCRIPTION
Meson always set -Wall and control the Optimisation level using the build
type.