### PR TITLE
Fix "local variable 'cflags' referenced before assignment" error

### DIFF
--- a/gst-build-helper/generate-cross-file.py
+++ b/gst-build-helper/generate-cross-file.py
@@ -44,6 +44,7 @@ def get_toolchain_prefix(options):
 
 
 def get_cflags(options):
+    cflags = ''
     if options.target_arch == "armv7":
         cflags = ' -march=armv7-a '
     cflags = cflags + ' ' + options.custom_cflags


### PR DESCRIPTION
When running `./generate-cross-file.py` the following error happens:
```
Traceback (most recent call last):
  File "generate-cross-file.py", line 234, in <module>
    env = get_subprocess_env(options)
  File "generate-cross-file.py", line 66, in get_subprocess_env
    cflags = get_cflags(options)
  File "generate-cross-file.py", line 49, in get_cflags
    cflags = cflags + ' ' + options.custom_cflags
UnboundLocalError: local variable 'cflags' referenced before assignment
```

These changes fix the error by assigning `cflags` beforehand.